### PR TITLE
[BUGFIX] CH-1

### DIFF
--- a/src/Crud/CrudTrait.php
+++ b/src/Crud/CrudTrait.php
@@ -117,6 +117,11 @@ trait CrudTrait
             return true;
         })->map->name->toArray();
 
+        if(!count($availableChoices)) {
+            $this->options->filterFields = new Collection();
+            return;
+        }
+
         $selectedFields = $this->components->choice(
             question: "Which columns should be available as filters on the listing page?",
             choices: $availableChoices,


### PR DESCRIPTION
- fix crud generate error when there are no filterable fields
Steps to reproduce without fix:
1. create a migration with only one string field, id, and timestamps
2. try to generate crud for that table